### PR TITLE
Changed resque-lock dependency

### DIFF
--- a/activejob-lock.gemspec
+++ b/activejob-lock.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activejob', '~> 4.2'
   s.add_dependency 'activesupport', '~> 4.2'
+  s.add_dependency "resque-lock", "~> 1.1"
 
   s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake", "~> 10.0"
 
-  s.add_development_dependency "resque-lock"
   s.add_development_dependency "rails"
   s.add_development_dependency "sqlite3"
 end

--- a/lib/activejob/lock/version.rb
+++ b/lib/activejob/lock/version.rb
@@ -1,5 +1,5 @@
 module Activejob
   module Lock
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
Why:
- We get Resque::Plugins not found errors unless a Resque Plugin is
  manually added to the Gemfile.

This change addresses the need by:
- Changed resque-lock to a dependency as opposed to a
  development_dependency.
- Added a version approximation to resque-lock dependency.
